### PR TITLE
Flag to bypass version bump

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ Version bump and release your package to npm with git operations and clean, flat
 - `--major` - Major release X.#.# for breaking changes
 - `--minor` - Minor release #.X.# for feature additions
 - `--patch` - Patch release #.#.X for bug fixes (default)
+- `--no-version` - Skip version bump
 - `--type <type>` - Custom release type (alpha, beta, rc, etc.)
 
 **Release Options:**

--- a/lib/commands/release.js
+++ b/lib/commands/release.js
@@ -59,6 +59,8 @@ function versionBump(currentVersion, type) {
       return `${parts[0]}.${parts[1] + 1}.0`
     case 'patch':
       return `${parts[0]}.${parts[1]}.${parts[2] + 1}`
+    case 'none':
+      return currentVersion
     default:
       // For pre-release versions like alpha, beta, rc
       if (currentVersion.includes(`-${type}`)) {
@@ -264,6 +266,10 @@ export async function releaseCommand(args) {
         type: 'boolean',
         description: 'Patch release #.#.X for bug fixes'
       },
+      'no-version': {
+        type: 'boolean',
+        description: 'Skip version bump'
+      },
       type: {
         type: 'string',
         description: 'Custom release type (alpha, beta, rc, etc.)'
@@ -342,6 +348,7 @@ Version Options (default: patch):
       --major             Major release X.#.# for breaking changes
       --minor             Minor release #.X.# for feature additions
       --patch             Patch release #.#.X for bug fixes (default)
+      --no-version        Skip version bump
       --type <type>       Custom release type (alpha, beta, rc, etc.)
 
 Publish Options:
@@ -385,6 +392,7 @@ This creates a clean, flat package structure in node_modules.
   const releaseType = releaseArgs.major ? 'major'
                     : releaseArgs.minor ? 'minor'
                     : releaseArgs.patch ? 'patch'
+                    : releaseArgs['no-version'] ? 'none'
                     : releaseArgs.type ? releaseArgs.type
                     : 'patch' // Default to patch
 

--- a/test/release.spec.ts
+++ b/test/release.spec.ts
@@ -63,6 +63,23 @@ const tests: TestTree = {
         }
       },
 
+      '--no-version': {
+        'skips bumping version': async () => {
+          const project = await ProjectFixture.create('no-version', {
+            'dist/index.mjs': 'export const test = "value"',
+            'package.json': JSON.stringify({
+              name: 'test-version',
+              version: '1.2.3',
+              type: 'module'
+            }, null, 2)
+          })
+
+          const result = await cli.run(['release', '--no-version', '--dry-run', '--no-git'], { cwd: project.dir })
+          expect(result.exitCode).toBe(0)
+          expect(result.stdout).toContain('v1.2.3 → v1.2.3')
+        }
+      },
+
       '--type=alpha': {
         'creates alpha pre-release': async () => {
           const project = await ProjectFixture.create('version-alpha', {


### PR DESCRIPTION
For a potential use case where the package file is already bumped via other means, this adds a `--no-version` flag (following the pattern of `--no-git`) to bypass the automatic version bump.